### PR TITLE
Fix tests to prepare for upcoming leaflet v2.2.0 release

### DIFF
--- a/tests/testthat/test-legend.R
+++ b/tests/testthat/test-legend.R
@@ -757,7 +757,7 @@ testthat::test_that('Awesome Legends', {
     addLegendAwesomeIcon(iconSet = iconSet) %>%
     getElement('dependencies') %>%
     vapply(getElement, 'name', FUN.VALUE = character(1)) %>%
-    testthat::expect_equal(c('leaflet-awesomemarkers', 'bootstrap'))
+    testthat::expect_contains(c('leaflet-awesomemarkers', 'bootstrap'))
   m %>%
     addLegendAwesomeIcon(iconSet = iconSet) %>%
     getElement(1) %>%


### PR DESCRIPTION
Hi @tomroh! We're preparing the next release of leaflet (v2.2.0, rstudio/leaflet#876) and noticed that our updates break a test in your package.

I've provided a relatively simple fix in this PR. In essence, `leaflet()` now includes its own dependencies in the `dependencies` item of the returned htmlwidgets object, which means that it contains both our dependencies and the dependencies your extension has added. I simply switch from `testthat::expect_equal()` to `testthat::expect_contains()`.

Do you think you'd be able to update your package on CRAN in the next two weeks? We're planning on submitting leaflet v2.2.0 on Tuesday, August 29 at the latest and are hoping we can have all reverse dependencies issues worked out by then. Thanks!