### PR TITLE
icon anchors were off when a thick strokes were used

### DIFF
--- a/R/legend.R
+++ b/R/legend.R
@@ -982,8 +982,8 @@ makeSymbolIcons <- function(shape,
   )
   leaflet::icons(
     iconUrl = unname(symbols),
-    iconAnchorX = width / 2,
-    iconAnchorY = height / 2
+    iconAnchorX = width / 2 + strokeWidth,
+    iconAnchorY = height / 2 + strokeWidth
   )
 }
 #' @param map


### PR DESCRIPTION
tmap 4 application:


```r
tmap_mode("view");tm_shape(NLD_prov) +
    tm_polygons() +
    tm_symbols(size = "population",
               lwd = 10,
               size.scale =tm_scale_continuous(values.scale = 4)) + tm_dots()
```

before fix:

<img width="1003" alt="Screenshot 2024-07-31 at 11 06 31" src="https://github.com/user-attachments/assets/5f9daa13-13cc-464b-99ce-376d6dfdd848">

after fix

<img width="1003" alt="Screenshot 2024-07-31 at 11 06 54" src="https://github.com/user-attachments/assets/394a6e7e-1eb2-4ee5-b545-eb00359d0028">

