### PR TITLE
Fix placement of values on `addLegendNumeric()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: leaflegend
 Type: Package
 Title: Add Custom Legends to 'leaflet' Maps
-Version: 1.2.8
+Version: 1.2.8.9000
 Authors@R: c(
     person("Thomas", "Roh", email = "thomas.roh@delveds.com", role = c("aut", "cre")),
     person("Ricardo Rodrigo", "Basa", email = "radbasa@gmail.com", role = c("ctb")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# leaflegend (development version)
+
+* Fixed `addLegendNumeric()` placing tick labels at the wrong position, relative
+to their value, in vertical orientation when manually specifying `bins`.
+
 # leaflegend 1.2.8
 
 * Intermediate ticks are now allowed for horizontal orientation in 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # leaflegend (development version)
 
 * Fixed `addLegendNumeric()` placing tick labels at the wrong position, relative
-to their value, in vertical orientation when manually specifying `bins`.
+to their value.
 
 # leaflegend 1.2.8
 

--- a/R/legend.R
+++ b/R/legend.R
@@ -1597,10 +1597,6 @@ addLegendNumeric <- function(map,
     breaks <- rev(breaks)
     offsets <- rev(offsets)
   }
-  # makeTicks()/makeTickText() measure vertical positions from the bottom
-  # (tickLocation = height - break), so the standardized breaks need to be
-  # flipped whenever exactly one of isVertical/decreasing is true, to keep
-  # tick positions and their labels aligned with the actual data values.
   if (xor(as.logical(isVertical), decreasing)) {
     stdBreaks <- (1 - (breaks - rng[1]) / diff(rng)) *
       (height * isVertical + width * isHorizontal)
@@ -2051,7 +2047,7 @@ makeLegendBinTicks <- function(bins, colors, shape, width, height, tickLength,
   htmlElements <- addNa(hasNa = hasNa, htmlElements = htmlElements,
     shape = shape, labels = naLabel, colors = naColor,
     labelStyle = labelStyle, height = width, width = width,
-    opacity = fillOpacity, fillOpacity = fillOpacity, strokeWidth = 0)  
+    opacity = fillOpacity, fillOpacity = fillOpacity, strokeWidth = 0)
   htmlElements
 }
 
@@ -2498,7 +2494,7 @@ sizeNumeric <- function(values, baseSize, minSize = NULL, maxSize = NULL,
 #' @export
 #'
 #' @rdname mapSymbols
-sizeBreaks <- function(values, breaks, baseSize, minSize = NULL, maxSize = NULL, 
+sizeBreaks <- function(values, breaks, baseSize, minSize = NULL, maxSize = NULL,
   ...) {
   stopifnot(baseSize > 0)
   if ( length(breaks) == 1 ) {
@@ -2572,7 +2568,7 @@ addLegendLine <- function(map,
                           ...) {
   shape <- 'rect'
   values <- parseValues(values = values, data = data)
-  sizes <- sizeBreaks(values, breaks, baseSize, minSize = minSize, 
+  sizes <- sizeBreaks(values, breaks, baseSize, minSize = minSize,
     maxSize = maxSize)
   if ( missing(color) ) {
     stopifnot( missing(color) & !missing(pal))

--- a/R/legend.R
+++ b/R/legend.R
@@ -1596,6 +1596,12 @@ addLegendNumeric <- function(map,
   if (decreasing) {
     breaks <- rev(breaks)
     offsets <- rev(offsets)
+  }
+  # makeTicks()/makeTickText() measure vertical positions from the bottom
+  # (tickLocation = height - break), so the standardized breaks need to be
+  # flipped whenever exactly one of isVertical/decreasing is true, to keep
+  # tick positions and their labels aligned with the actual data values.
+  if (xor(as.logical(isVertical), decreasing)) {
     stdBreaks <- (1 - (breaks - rng[1]) / diff(rng)) *
       (height * isVertical + width * isHorizontal)
   } else {
@@ -1609,9 +1615,6 @@ addLegendNumeric <- function(map,
   }
   if (is.null(labels)) {
     labels <- numberFormat(breaks)[i]
-  }
-  if (isVertical) {
-    labels <- rev(labels)
   }
   ticks <- makeTicks(breaks = stdBreaks[i], width = tickLength,
     height = height, strokeWidth = tickWidth, stroke = 'black', transform =
@@ -1647,10 +1650,8 @@ addLegendNumeric <- function(map,
 
 makeGradient <- function(breaks, pal, height, width, id, fillOpacity,
   orientation, shape) {
-  stops <- (breaks - min(breaks)) /
-    (max(breaks) - min(breaks))
-  colors <- pal(breaks)[order(stops)]
-  stops <- sort(stops)
+  stops <- seq(0, 1, length.out = length(breaks))
+  colors <- pal(breaks)
   offsets <- sprintf('%.03f%%', 100 * stops)
   curvePercent <- ifelse(shape == 'stadium', '10%', '0')
   if (orientation == 'vertical') {


### PR DESCRIPTION
Hi @tomroh,

Fixes #105 and #106.

This PR prevents the stdBreaks flipping when vertical *and* decreasing, which I think was causing the issue.

It also changes/simplifies how `stops`/`colors` are calculated, as they seemed to be unsorting the `breaks` provided to that helper.

Proof my reprexes now work:

```r
x <- 1:100

pal <- scales::col_numeric(palette = "viridis", domain = x)

leaflet::leaflet() |>
  leaflegend::addLegendNumeric(pal = pal, values = x) |>
  leaflegend::addLegendNumeric(pal = pal, values = x, bins = c(20, 30, 50))
```

<img width="549" height="528" alt="image" src="https://github.com/user-attachments/assets/80b0c47f-0139-4e25-9a69-f92e58f85d8a" />

```r
x <- c(52, 1272, 6408, 1061, 2658, 2386, 2408, 186, 56, 712, 538, 
       146, 214, 372, 180, 206, 490, 993, 202, 159, 222, 615, 492, 1132, 
       171, 406, 395, 282, 303, 252, 1226, 1471, 475, 516, 916, 480, 
       545, 576, 937, 728, 1374, 678, 572, 313, 754, 990, 676, 482, 
       641, 772, 543, 389, 365, 838, 704, 295, 637, 2, 661, 302, 88, 
       438, 418, 403, 195, 163, 185, 213, 0, 0, 243, 0, 0, 0, 25, 0, 
       0, 0, 0, 157, 124, 21, 0, 0, 556, 702, 0, 209, 66, 941, 386, 
       282, 0, 0, 52, 617, 0, 1956, 33, 1745, 1157, 0, 2163, 547, 778, 
       424, 166, 1747, 646, 807, 470, 242, 2119, 64, 60, 1256, 2, 201, 
       217, 100, 181, 0, 168, 232, 2249, 1476, 442, 148, 521, 958, 1403, 
       1474, 535, 1440, 388, 388, 365, 388, 388, 554, 1142, 1103, 160, 
       209, 56, 70, 17, 28, 42, 21, 14, 13)

pal <- scales::col_numeric(palette = viridisLite::turbo(100), domain = x)

leaflet::leaflet() |>
  leaflet::addLegend(pal = pal, values = x, opacity = 1) |>
  leaflegend::addLegendNumeric(pal = pal, values = x, position = "topright", height = 150)
```

<img width="552" height="362" alt="image" src="https://github.com/user-attachments/assets/19f1b201-8c90-429d-850a-232e6854f634" />
